### PR TITLE
tooltip bug fixed

### DIFF
--- a/inst/htmlwidgets/chorddiag.yaml
+++ b/inst/htmlwidgets/chorddiag.yaml
@@ -3,10 +3,10 @@ dependencies:
     version: 4.13.0
     src: htmlwidgets/lib/d3
     script: d3.min.js
-  - name: d3-tip
-    version: 0.8.1
-    src: htmlwidgets/lib/d3-tip
-    script: index.js
+  # - name: d3-tip
+  #   version: 0.8.1
+  #   src: htmlwidgets/lib/d3-tip
+  #   script: index.js
   - name: chorddiag
     version: 0.1.2.9000
     src: htmlwidgets/lib/chorddiag

--- a/inst/htmlwidgets/lib/chorddiag/chorddiag.css
+++ b/inst/htmlwidgets/lib/chorddiag/chorddiag.css
@@ -1,6 +1,5 @@
 .d3-tip {
   line-height: 1;
-  /*font-weight: bold;*/
   padding: 12px;
   background: rgba(0, 0, 0, 0.7);
   color: #fff;

--- a/inst/htmlwidgets/lib/chorddiag/chorddiag.js
+++ b/inst/htmlwidgets/lib/chorddiag/chorddiag.js
@@ -1,361 +1,418 @@
 HTMLWidgets.widget({
 
-  name: 'chorddiag',
-  type: 'output',
-
-  initialize: function(el, width, height) {
-
-    d3.select(el).append("svg")
-                 .attr("width", width)
-                 .attr("height", height);
-
-    return d3.chord();
-
-  },
-
-  resize: function(el, width, height, chord) {
-
-    d3.select(el).select("svg")
-                 .attr("width", width)
-                 .attr("height", height);
-
-    this.renderValue(el, chord.params, chord);
-
-  },
-
-  renderValue: function(el, params, chord) {
-
-    // save params for reference from resize method
-    chord.params = params;
-
-    var matrix = params.matrix,
-        options = params.options;
-
-    // get width and height, calculate min for use in diagram size
-    var width = el.offsetWidth,
-        height = el.offsetHeight,
-        d = Math.min(width, height);
-
-    var type = options.type,
-        margin = options.margin,
-        showGroupnames = options.showGroupnames,
-        groupNames = options.groupNames,
-        groupColors = options.groupColors,
-        groupThickness = options.groupThickness,
-        groupPadding = options.groupPadding,
-        groupnamePadding = options.groupnamePadding,
-        groupnameFontsize = options.groupnameFontsize,
-        groupedgeColor = options.groupedgeColor,
-        chordedgeColor = options.chordedgeColor,
-        categoryNames = options.categoryNames,
-        categorynamePadding = options.categorynamePadding,
-        categorynameFontsize = options.categorynameFontsize,
-        showTicks = options.showTicks,
-        tickInterval = options.tickInterval,
-        ticklabelFontsize = options.ticklabelFontsize,
-        fadeLevel = options.fadeLevel,
-        showTooltips = options.showTooltips,
-        showZeroTooltips = options.showZeroTooltips,
-        tooltipNames = options.tooltipNames,
-        tooltipFontsize = options.tooltipFontsize,
-        tooltipUnit = options.tooltipUnit,
-        tooltipGroupConnector = options.tooltipGroupConnector,
-        precision = options.precision,
-        clickAction = options.clickAction,
-        clickGroupAction = options.clickGroupAction;
-
-    d3.select(el).selectAll("div.d3-tip").remove();
-
-    if (showTooltips) {
-        var chordTip = d3.tip()
-                         .attr('class', 'd3-tip')
-                         .style("font-size", tooltipFontsize + "px")
-                         .style("font-family", "sans-serif")
-                         .direction('n')
-                         .offset([10, 10])
-                         .html(function(d) {
-                             // indexes
-                             var i = d.source.index,
-                                 j = d.target.index;
-                             // values
-                             var vij = sigFigs(matrix[i][j], precision),
-                                 vji = sigFigs(matrix[j][i], precision);
-                             var dir1 = tooltipNames[i] + tooltipGroupConnector + tooltipNames[j] + ": " + vij + tooltipUnit,
-                                 dir2 = tooltipNames[j] + tooltipGroupConnector + tooltipNames[i] + ": " + vji + tooltipUnit;
-                             if (type == "directional") {
-                                 if (i == j) {
-                                     return dir1;
-                                 } else {
-                                     if (showZeroTooltips) {
-                                         return dir1 + "</br>" + dir2;
-                                     } else {
-                                         return dir1 + (vji > 0 ? "</br>" + dir2 : "");
-                                     }
-                                 }
-                             } else if (type == "bipartite") {
-                                 return dir2;
-                             }
-                         });
-
-        var groupTip = d3.tip()
-                         .attr('class', 'd3-tip')
-                         .style("font-size", tooltipFontsize + "px")
-                         .style("font-family", "sans-serif")
-                         .direction('n')
-                         .offset([10, 10])
-                         .html(function(d) {
-                             var value = sigFigs(d.value, precision);
-                             return tooltipNames[d.index] + " (total): " + value + tooltipUnit;
-                         });
-    }
-
-    var svgContainer = d3.select(el).select("svg");
-    svgContainer.selectAll("*").remove();
-
-    // apply chord settings and data
-    chord = chord.padAngle(groupPadding)
-                 .sortSubgroups(d3.descending)(matrix);
-
-    // calculate outer and inner radius for chord diagram
-    var outerRadius = (d - 2 * margin) / 2,
-        innerRadius = outerRadius * (1 - groupThickness);
-
-    // create ordinal color fill scale from groupColors
-    var fillScale = d3.scaleOrdinal()
-                            .domain(d3.range(matrix.length))
-                            .range(groupColors);
-
-    // calculate horizontal and vertical translation values
-    var xTranslate = Math.max(width / 2, outerRadius + margin),
-        yTranslate = Math.max(height / 2, outerRadius + margin);
-
-    var svg = svgContainer.append("g");
-    svg.attr("transform", "translate(" + xTranslate + "," + yTranslate + ")");
-
-    if (showTooltips) {
-       svg.call(chordTip)
-          .call(groupTip);
-    }
-
-    // create groups
-    var groups = svg.append("g").attr("class", "groups")
-                    .selectAll("path")
-                    .data(chord.groups)
-                    .enter().append("path").attr("id", function(d, i) {
-                           return "group-" + groupNames[i];
-                    });
-
-    // style groups and define mouse events
-    groups.style("fill", function(d) { return fillScale(d.index); })
-          .style("stroke", function(d) { return fillScale(d.index); })
-          .attr("d", d3.arc().innerRadius(innerRadius).outerRadius(outerRadius))
-          .on("mouseover", function(d) {
-              if (showTooltips) groupTip.show(d,this);
+    name: 'chorddiag',
+    type: 'output',
+  
+    initialize: function(el, width, height) {
+      d3.select(el).append("svg")
+                   .attr("width", width)
+                   .attr("height", height);
+  
+      return d3.chord();
+    },
+  
+    resize: function(el, width, height, chord) {
+      d3.select(el).select("svg")
+                   .attr("width", width)
+                   .attr("height", height);
+  
+      this.renderValue(el, chord.params, chord);
+    },
+  
+    renderValue: function(el, params, chord) {
+      // save params for reference from resize method
+      chord.params = params;
+  
+      var matrix = params.matrix,
+          options = params.options;
+  
+      // get width and height, calculate min for use in diagram size
+      var width = el.offsetWidth,
+          height = el.offsetHeight,
+          d = Math.min(width, height);
+  
+      var type = options.type,
+          margin = options.margin,
+          showGroupnames = options.showGroupnames,
+          groupNames = options.groupNames,
+          groupColors = options.groupColors,
+          groupThickness = options.groupThickness,
+          groupPadding = options.groupPadding,
+          groupnamePadding = options.groupnamePadding,
+          groupnameFontsize = options.groupnameFontsize,
+          groupedgeColor = options.groupedgeColor,
+          chordedgeColor = options.chordedgeColor,
+          categoryNames = options.categoryNames,
+          categorynamePadding = options.categorynamePadding,
+          categorynameFontsize = options.categorynameFontsize,
+          showTicks = options.showTicks,
+          tickInterval = options.tickInterval,
+          ticklabelFontsize = options.ticklabelFontsize,
+          fadeLevel = options.fadeLevel,
+          showTooltips = options.showTooltips,
+          showZeroTooltips = options.showZeroTooltips,
+          tooltipNames = options.tooltipNames,
+          tooltipFontsize = options.tooltipFontsize,
+          tooltipUnit = options.tooltipUnit,
+          tooltipGroupConnector = options.tooltipGroupConnector,
+          precision = options.precision,
+          clickAction = options.clickAction,
+          clickGroupAction = options.clickGroupAction;
+      
+      // actually pointless, to remove the tooltip-divs. the Shiny-server rerenders 
+      // the entire ChordDiagram on update. Thus querying for 'div.d3-tip' returns an empty set:
+      d3.select(el).selectAll("div.d3-tip").remove();
+  
+      let TOOL_TIP_TYPE = {
+          GROUP: 1, // don't start enum index on 0 - now it can be used to check for valid TOOL_TIP_TYPE like so: if(type){ ... }else{ /*invalid TOOL_TIP_TYPE*/ }
+          CHORD: 2
+      };
+  
+      var svgContainer = d3.select(el).select("svg");
+      svgContainer.selectAll("*").remove();
+  
+      if (showTooltips) {
+          var toolTip = d3.select(el)
+              .append('div')
+              .attr('class', 'd3-tip')
+              .style("font-size", tooltipFontsize + "px")
+              .style("font-family", "sans-serif")
+              .style('position', 'fixed')
+              .style('top', "px")
+              .style('left', "0px")
+              .style('opacity', 0)
+              ;
+          
+          function genChordToolTipLabel(d){
+              var i = d.source.index,
+              j = d.target.index;
+              // values
+              var vij = sigFigs(matrix[i][j], precision),
+                  vji = sigFigs(matrix[j][i], precision);
+              var dir1 = tooltipNames[i] + tooltipGroupConnector + tooltipNames[j] + ": " + vij + tooltipUnit,
+                  dir2 = tooltipNames[j] + tooltipGroupConnector + tooltipNames[i] + ": " + vji + tooltipUnit;
+              if (type == "directional") {
+                  if (i == j) {
+                      return dir1;
+                  } else {
+                      if (showZeroTooltips) {
+                          return dir1 + "</br>" + dir2;
+                      } else {
+                          return dir1 + (vji > 0 ? "</br>" + dir2 : "");
+                      }
+                  }
+              } else if (type == "bipartite") {
+                  return dir2;
+              }
+          }
+          function genGroupToolTipLabel(d){
+              var value = sigFigs(d.value, precision);
+              return tooltipNames[d.index] + " (total): " + value + tooltipUnit;
+          }
+  
+          toolTip.type = TOOL_TIP_TYPE.CHORD; // set in mouse-event-handler (mouseMove, mouseLeave, mouseEnter);
+  
+          toolTip.genLabel = function(d){
+              if(this.type == TOOL_TIP_TYPE.GROUP){
+                  return genGroupToolTipLabel(d);
+              }else{ // this.type == TOOL_TIP_TYPE.CHORD
+                  return genChordToolTipLabel(d);
+              }
+          }
+          
+          toolTip.setPosition = function(mouseEvnt){
+              const mouse = {x: mouseEvnt.clientX, y: mouseEvnt.clientY}
+              const tolTpBndgRct = toolTip.node().getBoundingClientRect();
+              let tarX = mouse.x - Math.floor(tolTpBndgRct.width * 0.5);
+              let tarY = mouse.y - tolTpBndgRct.height - 20;
+              toolTip
+                  .style('top',  `${tarY}px`)
+                  .style('left', `${tarX}px`);
+          };
+          toolTip.show = function(d, mouseEvnt){
+              toolTip
+                  .style('opacity', 1)
+                  .html(function() {
+                      return toolTip.genLabel(d);
+                  });
+              toolTip.setPosition(mouseEvnt);
+          };
+          toolTip.hide = function(){
+              toolTip
+                  .style('opacity', 0);
+          };
+  
+          toolTip.onMouseOver = function(d){
+              if (showTooltips){
+                  toolTip.show(d, d3.event);
+              }
+          }
+          toolTip.onChordMouseOver = function(d){
+              this.type = TOOL_TIP_TYPE.CHORD;
+              this.onMouseOver(d);
+          }
+          toolTip.onGroupMouseOver = function(d){
+              this.type = TOOL_TIP_TYPE.GROUP;
+              this.onMouseOver(d);
+          }
+          toolTip.onMouseOut = function(){
+              if (showTooltips) toolTip.hide();
+          }
+          toolTip.onMouseMove = function(){
+              if(showTooltips) toolTip.setPosition(d3.event);
+          }
+      }
+  
+      // apply chord settings and data
+      chord = chord.padAngle(groupPadding)
+                   .sortSubgroups(d3.descending)(matrix);
+  
+      // calculate outer and inner radius for chord diagram
+      var outerRadius = (d - 2 * margin) / 2,
+          innerRadius = outerRadius * (1 - groupThickness);
+  
+      // create ordinal color fill scale from groupColors
+      var fillScale = d3.scaleOrdinal()
+                              .domain(d3.range(matrix.length))
+                              .range(groupColors);
+  
+      // calculate horizontal and vertical translation values
+      var xTranslate = Math.max(width / 2, outerRadius + margin),
+          yTranslate = Math.max(height / 2, outerRadius + margin);
+  
+      var svg = svgContainer.append("g");
+      svg.attr("transform", "translate(" + xTranslate + "," + yTranslate + ")");
+  
+      // create groups
+      var groups = svg.append("g").attr("class", "groups")
+                      .selectAll("path")
+                      .data(chord.groups)
+                      .enter().append("path").attr("id", function(d, i) {
+                             return "group-" + groupNames[i];
+                      });
+  
+      // style groups and define mouse events
+      groups.style("fill", function(d) { return fillScale(d.index); })
+            .style("stroke", function(d) { return fillScale(d.index); })
+            .attr("d", d3.arc().innerRadius(innerRadius).outerRadius(outerRadius))
+            .on("mouseover", function(d) {
+              toolTip.onGroupMouseOver(d);
               return groupFade(d, fadeLevel);
-          })
-          .on("mouseout", function(d) {
-              if (showTooltips) groupTip.hide(d);
+            })
+            .on("mouseout", function(d) {
+              toolTip.onMouseOut();
               return groupFade(d, 1);
-          })
-          .on("click", clickGroup);
-
-    if (groupedgeColor) {
-        groups.style("stroke", groupedgeColor);
-    } else {
-        groups.style("stroke", function(d) { return fillScale(d.index); });
-    }
-
-    if (showTicks) {
-        // create ticks for groups
-        var ticks = svg.append("g").attr("class", "ticks")
-                       .selectAll("g")
-                       .data(chord.groups)
-                       .enter().append("g") //.attr("class", "ticks")
-                       .attr("id", function(d, i) {
-                           return "ticks-" + groupNames[i];
-                       })
-                       .selectAll("g")
-                       .data(groupTicks)
-                       .enter().append("g").attr("class", "tick")
-                       .attr("transform", function(d) {
-                           return "rotate(" + (d.angle * 180 / Math.PI - 90) + ")"
-                               + "translate(" + outerRadius + ", 0)";
-                       });
-
-        // add tick marks
-        ticks.append("line")
-             .attr("x1", 1)
-             .attr("y1", 0)
-             .attr("x2", 5)
-             .attr("y2", 0)
-             .style("stroke", "#000");
-
-        // add tick labels
-        ticks.append("text")
-             .attr("x", 0)
-             .attr("dy", ".35em")
-             .style("font-size", ticklabelFontsize + "px")
-             .style("font-family", "sans-serif")
-             .attr("transform", function(d) { return d.angle > Math.PI ? "rotate(180)translate(-8)" : "translate(8)"; })
-             .style("text-anchor", function(d) { return d.angle > Math.PI ? "end" : "start"; })
-             .text(function(d) { return d.label; });
-    }
-
-    // create chords
-    var chords = svg.append("g").attr("class", "chords")
-                    .selectAll("path")
-                    .data(chord)
-                    .enter().append("path").attr("id", function(d, i) {
-                        return "chord-" + groupNames[d.source.index]
-                               + "-" + groupNames[d.target.index];
-                    })
-                    .attr("d", d3.ribbon().radius(innerRadius));
-
-    // style chords and define mouse events
-    chords.style("fill", function(d) { return fillScale(d.target.index); })
-          .style("stroke", chordedgeColor)
-          .style("fill-opacity", 0.67)
-          .style("stroke-width", "0.5px")
-          .style("opacity", 1)
-          .on("mouseover", function(d) {
-              if (showTooltips) chordTip.show(d, this);
-              return chordFade(d, fadeLevel);
-          })
-          .on("mouseout", function(d) {
-              if (showTooltips) chordTip.hide(d);
-              return chordFade(d, 1);
-          })
-          .on("click", click);
-
-    // create group labels
-    if (showGroupnames) {
-        var names = svg.append("g").attr("class", "names")
-                       .selectAll("g")
-                       .data(chord.groups)
-                       .enter().append("g").attr("class", "name")
-                       .on("mouseover", function(d) {
-                           return groupFade(d, fadeLevel);
-                       })
-                       .on("mouseout", function(d) {
-                           return groupFade(d, 1);
-                       })
-                       .selectAll("g")
-                       .data(groupLabels)
-                       .enter().append("g").attr("id", function(d) {
-                           return "label-" + d.label;
-                       })
-                       .attr("transform", function(d) {
-                           return "rotate(" + (d.angle * 180 / Math.PI - 90) + ")"
-                                + "translate(" + (outerRadius + d.padding) + ", 0)";
-                       });
-        names.append("text")
-            .attr("x", 0)
-            .attr("dy", ".35em")
-            .style("font-size", groupnameFontsize + "px")
-            .style("font-family", "sans-serif")
-            .attr("transform", function(d) {
-                return d.handside == "left" ? "rotate(180)" : null;
             })
-            .style("text-anchor", function(d) { return d.handside == "left" ? "end" : "start"; })
-            .text(function(d) { return d.label; })
-            .attr("id", function(d) { return d.label; });
-    }
-
-    if (categoryNames) {
-        var categories = svg.append("g").attr("class", "categories")
-                            .selectAll("g")
-                            .data(categoryNames)
-                            .enter().append("g").attr("class", "category")
-                            .selectAll("g")
-                            .data(categoryLabels)
-                            .enter().append("g")
-                            .style("fill", "black")
-                            .attr("id", function(d) {
-                                return "label-" + d.label;
-                            })
-                            .attr("transform", function(d) {
-                                return "rotate(" + (d.angle * 180 / Math.PI) + ")"
-                                    + "translate(" + (outerRadius + categorynamePadding) + ", 0)";
-                            });
-
-        categories.append("text")
-                  .attr("x", 0)
-                  .attr("dy", ".35em")
-                  .style("font-size", categorynameFontsize + "px")
-                  .style("font-family", "sans-serif")
-                  .style("font-weight", "bold")
-                  .attr("transform", function(d, i) { return i ? "rotate(270)" : "rotate(90)"; })
-                  .style("text-anchor", "middle")
-                  .text(function(d) { return d.label; })
-                  .attr("id", function(d) { return d.label; });
-    }
-
-    function categoryLabels(d, i) {
+            .on("mousemove", function(d){
+              toolTip.onMouseMove();
+            })
+            .on("click", clickGroup);
+  
+      if (groupedgeColor) {
+          groups.style("stroke", groupedgeColor);
+      } else {
+          groups.style("stroke", function(d) { return fillScale(d.index); });
+      }
+  
+      if (showTicks) {
+          // create ticks for groups
+          var ticks = svg.append("g").attr("class", "ticks")
+                         .selectAll("g")
+                         .data(chord.groups)
+                         .enter().append("g") //.attr("class", "ticks")
+                         .attr("id", function(d, i) {
+                             return "ticks-" + groupNames[i];
+                         })
+                         .selectAll("g")
+                         .data(groupTicks)
+                         .enter().append("g").attr("class", "tick")
+                         .attr("transform", function(d) {
+                             return "rotate(" + (d.angle * 180 / Math.PI - 90) + ")"
+                                 + "translate(" + outerRadius + ", 0)";
+                         });
+  
+          // add tick marks
+          ticks.append("line")
+               .attr("x1", 1)
+               .attr("y1", 0)
+               .attr("x2", 5)
+               .attr("y2", 0)
+               .style("stroke", "#000");
+  
+          // add tick labels
+          ticks.append("text")
+               .attr("x", 0)
+               .attr("dy", ".35em")
+               .style("font-size", ticklabelFontsize + "px")
+               .style("font-family", "sans-serif")
+               .attr("transform", function(d) { return d.angle > Math.PI ? "rotate(180)translate(-8)" : "translate(8)"; })
+               .style("text-anchor", function(d) { return d.angle > Math.PI ? "end" : "start"; })
+               .text(function(d) { return d.label; });
+      }
+  
+      // create chords
+      var chords = svg.append("g").attr("class", "chords")
+                      .selectAll("path")
+                      .data(chord)
+                      .enter().append("path").attr("id", function(d, i) {
+                          return "chord-" + groupNames[d.source.index]
+                                 + "-" + groupNames[d.target.index];
+                      })
+                      .attr("d", d3.ribbon().radius(innerRadius));
+  
+      // style chords and define mouse events
+      chords.style("fill", function(d) { return fillScale(d.target.index); })
+            .style("stroke", chordedgeColor)
+            .style("fill-opacity", 0.67)
+            .style("stroke-width", "0.5px")
+            .style("opacity", 1)
+            .on("mouseover", function(d) {
+              toolTip.onChordMouseOver(d);
+              chordFade(d, fadeLevel);
+            })
+            .on("mouseout", function(d) {
+              toolTip.onMouseOut();
+              chordFade(d, 1);
+            })
+            .on("mousemove", function(d){
+              toolTip.onMouseMove();
+            })
+            .on("click", click);
+  
+      // create group labels
+      if (showGroupnames) {
+          var names = svg.append("g").attr("class", "names")
+                         .selectAll("g")
+                         .data(chord.groups)
+                         .enter().append("g").attr("class", "name")
+                         .on("mouseover", function(d) {
+                             return groupFade(d, fadeLevel);
+                         })
+                         .on("mouseout", function(d) {
+                             return groupFade(d, 1);
+                         })
+                         .selectAll("g")
+                         .data(groupLabels)
+                         .enter().append("g").attr("id", function(d) {
+                             return "label-" + d.label;
+                         })
+                         .attr("transform", function(d) {
+                             return "rotate(" + (d.angle * 180 / Math.PI - 90) + ")"
+                                  + "translate(" + (outerRadius + d.padding) + ", 0)";
+                         });
+          names.append("text")
+              .attr("x", 0)
+              .attr("dy", ".35em")
+              .style("font-size", groupnameFontsize + "px")
+              .style("font-family", "sans-serif")
+              .attr("transform", function(d) {
+                  return d.handside == "left" ? "rotate(180)" : null;
+              })
+              .style("text-anchor", function(d) { return d.handside == "left" ? "end" : "start"; })
+              .text(function(d) { return d.label; })
+              .attr("id", function(d) { return d.label; });
+      }
+  
+      if (categoryNames) {
+          var categories = svg.append("g").attr("class", "categories")
+                              .selectAll("g")
+                              .data(categoryNames)
+                              .enter().append("g").attr("class", "category")
+                              .selectAll("g")
+                              .data(categoryLabels)
+                              .enter().append("g")
+                              .style("fill", "black")
+                              .attr("id", function(d) {
+                                  return "label-" + d.label;
+                              })
+                              .attr("transform", function(d) {
+                                  return "rotate(" + (d.angle * 180 / Math.PI) + ")"
+                                      + "translate(" + (outerRadius + categorynamePadding) + ", 0)";
+                              });
+  
+          categories.append("text")
+                    .attr("x", 0)
+                    .attr("dy", ".35em")
+                    .style("font-size", categorynameFontsize + "px")
+                    .style("font-family", "sans-serif")
+                    .style("font-weight", "bold")
+                    .attr("transform", function(d, i) { return i ? "rotate(270)" : "rotate(90)"; })
+                    .style("text-anchor", "middle")
+                    .text(function(d) { return d.label; })
+                    .attr("id", function(d) { return d.label; });
+      }
+  
+      function categoryLabels(d, i) {
+          return [{
+            angle: i * Math.PI,
+            label: d
+          }];
+      }
+  
+      // returns an array of tick angles and labels, given a group
+      function groupTicks(d) {
+        var k = (d.endAngle - d.startAngle) / d.value;
+        return d3.range(0, d.value, tickInterval).map(function(v, i) {
+          return {
+            angle: v * k + d.startAngle,
+            label: i % 5 ? null : v
+          };
+        });
+      }
+  
+      function groupLabels(d) {
+        var a = (d.startAngle + d.endAngle) / 2;
         return [{
-          angle: i * Math.PI,
-          label: d
-        }];
-    }
-
-    // returns an array of tick angles and labels, given a group
-    function groupTicks(d) {
-      var k = (d.endAngle - d.startAngle) / d.value;
-      return d3.range(0, d.value, tickInterval).map(function(v, i) {
-        return {
-          angle: v * k + d.startAngle,
-          label: i % 5 ? null : v
-        };
-      });
-    }
-
-    function groupLabels(d) {
-      var a = (d.startAngle + d.endAngle) / 2;
-      return [{
-          angle: a,
-          handside: (a < Math.PI) ? "right" : "left",
-          label: groupNames[d.index],
-          padding: groupnamePadding[d.index]
-        }];
-    }
-
-    // returns an event handler for fading all chords not belonging to a
-    // specific group
-    function groupFade(g, opacity) {
-        svg.selectAll(".chords path")
-            .filter(function(d) { return d.source.index != g.index
-                                      && d.target.index != g.index; })
-            .transition()
-            .style("opacity", opacity);
-    }
-
-    // returns an event handler for fading all chords except for the one
-    // given
-    function chordFade(g, opacity) {
-        svg.selectAll(".chords path")
-            .filter(function(d) { return d.source.index != g.source.index
-                                      || d.target.index != g.target.index;
-            })
-            .transition()
-            .style("opacity", opacity);
-    }
-
-    // round to significant figures / digits
-    function sigFigs(n, sig) {
-        if (n == 0) { return n}
-        if (sig == "null") { sig = 7; }
-        var mult = Math.pow(10, sig - Math.floor(Math.log(n) / Math.LN10) - 1);
-        return Math.round(n * mult) / mult;
-    }
-
-    function click(d) {
-      return eval(clickAction);
-    }
-
-    function clickGroup(d) {
-        return eval(clickGroupAction)
-    }
-
-  }  // end renderValue function
-
-});
-
+            angle: a,
+            handside: (a < Math.PI) ? "right" : "left",
+            label: groupNames[d.index],
+            padding: groupnamePadding[d.index]
+          }];
+      }
+  
+      // returns an event handler for fading all chords not belonging to a
+      // specific group
+      function groupFade(g, opacity) {
+          svg.selectAll(".chords path")
+              .filter(function(d) { return d.source.index != g.index
+                                        && d.target.index != g.index; })
+              .transition()
+              .style("opacity", opacity);
+      }
+  
+      // returns an event handler for fading all chords except for the one
+      // given
+      function chordFade(g, opacity) {
+          svg.selectAll(".chords path")
+              .filter(function(d) { return d.source.index != g.source.index
+                                        || d.target.index != g.target.index;
+              })
+              .transition()
+              .style("opacity", opacity);
+      }
+  
+      // round to significant figures / digits
+      function sigFigs(n, sig) {
+          if (n == 0) { return n}
+          if (sig == "null") { sig = 7; }
+          var mult = Math.pow(10, sig - Math.floor(Math.log(n) / Math.LN10) - 1);
+          return Math.round(n * mult) / mult;
+      }
+  
+      function click(d) {
+          if(!clickAction)return;
+  
+          return eval(clickAction);
+      }
+  
+      function clickGroup(d) {
+          if(!clickGroupAction)return;
+          // Shiny.setInputValue(clickGroupAction, d, {priority: "event"});
+  
+          return eval(clickGroupAction)
+      }
+  
+    }  // end renderValue function
+  });
+  
+  

--- a/inst/htmlwidgets/lib/d3-tip/index.js
+++ b/inst/htmlwidgets/lib/d3-tip/index.js
@@ -1,338 +1,341 @@
-(function (global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('d3-collection'), require('d3-selection')) :
-  typeof define === 'function' && define.amd ? define(['d3-collection', 'd3-selection'], factory) :
-  (global.d3 = global.d3 || {}, global.d3.tip = factory(global.d3,global.d3));
-}(this, (function (d3Collection,d3Selection) { 'use strict';
+// tooltips are generated in chorddiag.js due to some bugs caused by this code
+// -> this library ist not used anymore an therefore commented out
 
-  /**
-   * d3.tip
-   * Copyright (c) 2013-2017 Justin Palmer
-   *
-   * Tooltips for d3.js SVG visualizations
-   */
-  // Public - constructs a new tooltip
-  //
-  // Returns a tip
-  function index() {
-    var direction   = d3TipDirection,
-        offset      = d3TipOffset,
-        html        = d3TipHTML,
-        rootElement = document.body,
-        node        = initNode(),
-        svg         = null,
-        point       = null,
-        target      = null;
+// (function (global, factory) {
+//   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('d3-collection'), require('d3-selection')) :
+//   typeof define === 'function' && define.amd ? define(['d3-collection', 'd3-selection'], factory) :
+//   (global.d3 = global.d3 || {}, global.d3.tip = factory(global.d3,global.d3));
+// }(this, (function (d3Collection,d3Selection) { 'use strict';
 
-    function tip(vis) {
-      svg = getSVGNode(vis);
-      if (!svg) return
-      point = svg.createSVGPoint();
-      rootElement.appendChild(node);
-    }
+//   /**
+//    * d3.tip
+//    * Copyright (c) 2013-2017 Justin Palmer
+//    *
+//    * Tooltips for d3.js SVG visualizations
+//    */
+//   // Public - constructs a new tooltip
+//   //
+//   // Returns a tip
+//   function index() {
+//     var direction   = d3TipDirection,
+//         offset      = d3TipOffset,
+//         html        = d3TipHTML,
+//         rootElement = document.body,
+//         node        = initNode(),
+//         svg         = null,
+//         point       = null,
+//         target      = null;
 
-    // Public - show the tooltip on the screen
-    //
-    // Returns a tip
-    tip.show = function() {
-      var args = Array.prototype.slice.call(arguments);
-      if (args[args.length - 1] instanceof SVGElement) target = args.pop();
+//     function tip(vis) {
+//       svg = getSVGNode(vis);
+//       if (!svg) return
+//       point = svg.createSVGPoint();
+//       rootElement.appendChild(node);
+//     }
 
-      var content = html.apply(this, args),
-          poffset = offset.apply(this, args),
-          dir     = direction.apply(this, args),
-          nodel   = getNodeEl(),
-          i       = directions.length,
-          coords,
-          scrollTop  = document.documentElement.scrollTop ||
-        rootElement.scrollTop,
-          scrollLeft = document.documentElement.scrollLeft ||
-        rootElement.scrollLeft;
+//     // Public - show the tooltip on the screen
+//     //
+//     // Returns a tip
+//     tip.show = function() {
+//       var args = Array.prototype.slice.call(arguments);
+//       if (args[args.length - 1] instanceof SVGElement) target = args.pop();
 
-      nodel.html(content)
-        .style('opacity', 1).style('pointer-events', 'all');
+//       var content = html.apply(this, args),
+//           poffset = offset.apply(this, args),
+//           dir     = direction.apply(this, args),
+//           nodel   = getNodeEl(),
+//           i       = directions.length,
+//           coords,
+//           scrollTop  = document.documentElement.scrollTop ||
+//         rootElement.scrollTop,
+//           scrollLeft = document.documentElement.scrollLeft ||
+//         rootElement.scrollLeft;
 
-      while (i--) nodel.classed(directions[i], false);
-      coords = directionCallbacks.get(dir).apply(this);
-      nodel.classed(dir, true)
-        .style('top', (coords.top + poffset[0]) + scrollTop + 'px')
-        .style('left', (coords.left + poffset[1]) + scrollLeft + 'px');
+//       nodel.html(content)
+//         .style('opacity', 1).style('pointer-events', 'all');
 
-      return tip
-    };
+//       while (i--) nodel.classed(directions[i], false);
+//       coords = directionCallbacks.get(dir).apply(this);
+//       nodel.classed(dir, true)
+//         .style('top', (coords.top + poffset[0]) + scrollTop + 'px')
+//         .style('left', (coords.left + poffset[1]) + scrollLeft + 'px');
 
-    // Public - hide the tooltip
-    //
-    // Returns a tip
-    tip.hide = function() {
-      var nodel = getNodeEl();
-      nodel.style('opacity', 0).style('pointer-events', 'none');
-      return tip
-    };
+//       return tip
+//     };
 
-    // Public: Proxy attr calls to the d3 tip container.
-    // Sets or gets attribute value.
-    //
-    // n - name of the attribute
-    // v - value of the attribute
-    //
-    // Returns tip or attribute value
-    // eslint-disable-next-line no-unused-vars
-    tip.attr = function(n, v) {
-      if (arguments.length < 2 && typeof n === 'string') {
-        return getNodeEl().attr(n)
-      }
+//     // Public - hide the tooltip
+//     //
+//     // Returns a tip
+//     tip.hide = function() {
+//       var nodel = getNodeEl();
+//       nodel.style('opacity', 0).style('pointer-events', 'none');
+//       return tip
+//     };
 
-      var args =  Array.prototype.slice.call(arguments);
-      d3Selection.selection.prototype.attr.apply(getNodeEl(), args);
-      return tip
-    };
+//     // Public: Proxy attr calls to the d3 tip container.
+//     // Sets or gets attribute value.
+//     //
+//     // n - name of the attribute
+//     // v - value of the attribute
+//     //
+//     // Returns tip or attribute value
+//     // eslint-disable-next-line no-unused-vars
+//     tip.attr = function(n, v) {
+//       if (arguments.length < 2 && typeof n === 'string') {
+//         return getNodeEl().attr(n)
+//       }
 
-    // Public: Proxy style calls to the d3 tip container.
-    // Sets or gets a style value.
-    //
-    // n - name of the property
-    // v - value of the property
-    //
-    // Returns tip or style property value
-    // eslint-disable-next-line no-unused-vars
-    tip.style = function(n, v) {
-      if (arguments.length < 2 && typeof n === 'string') {
-        return getNodeEl().style(n)
-      }
+//       var args =  Array.prototype.slice.call(arguments);
+//       d3Selection.selection.prototype.attr.apply(getNodeEl(), args);
+//       return tip
+//     };
 
-      var args = Array.prototype.slice.call(arguments);
-      d3Selection.selection.prototype.style.apply(getNodeEl(), args);
-      return tip
-    };
+//     // Public: Proxy style calls to the d3 tip container.
+//     // Sets or gets a style value.
+//     //
+//     // n - name of the property
+//     // v - value of the property
+//     //
+//     // Returns tip or style property value
+//     // eslint-disable-next-line no-unused-vars
+//     tip.style = function(n, v) {
+//       if (arguments.length < 2 && typeof n === 'string') {
+//         return getNodeEl().style(n)
+//       }
 
-    // Public: Set or get the direction of the tooltip
-    //
-    // v - One of n(north), s(south), e(east), or w(west), nw(northwest),
-    //     sw(southwest), ne(northeast) or se(southeast)
-    //
-    // Returns tip or direction
-    tip.direction = function(v) {
-      if (!arguments.length) return direction
-      direction = v == null ? v : functor(v);
+//       var args = Array.prototype.slice.call(arguments);
+//       d3Selection.selection.prototype.style.apply(getNodeEl(), args);
+//       return tip
+//     };
 
-      return tip
-    };
+//     // Public: Set or get the direction of the tooltip
+//     //
+//     // v - One of n(north), s(south), e(east), or w(west), nw(northwest),
+//     //     sw(southwest), ne(northeast) or se(southeast)
+//     //
+//     // Returns tip or direction
+//     tip.direction = function(v) {
+//       if (!arguments.length) return direction
+//       direction = v == null ? v : functor(v);
 
-    // Public: Sets or gets the offset of the tip
-    //
-    // v - Array of [x, y] offset
-    //
-    // Returns offset or
-    tip.offset = function(v) {
-      if (!arguments.length) return offset
-      offset = v == null ? v : functor(v);
+//       return tip
+//     };
 
-      return tip
-    };
+//     // Public: Sets or gets the offset of the tip
+//     //
+//     // v - Array of [x, y] offset
+//     //
+//     // Returns offset or
+//     tip.offset = function(v) {
+//       if (!arguments.length) return offset
+//       offset = v == null ? v : functor(v);
 
-    // Public: sets or gets the html value of the tooltip
-    //
-    // v - String value of the tip
-    //
-    // Returns html value or tip
-    tip.html = function(v) {
-      if (!arguments.length) return html
-      html = v == null ? v : functor(v);
+//       return tip
+//     };
 
-      return tip
-    };
+//     // Public: sets or gets the html value of the tooltip
+//     //
+//     // v - String value of the tip
+//     //
+//     // Returns html value or tip
+//     tip.html = function(v) {
+//       if (!arguments.length) return html
+//       html = v == null ? v : functor(v);
 
-    // Public: sets or gets the root element anchor of the tooltip
-    //
-    // v - root element of the tooltip
-    //
-    // Returns root node of tip
-    tip.rootElement = function(v) {
-      if (!arguments.length) return rootElement
-      rootElement = v == null ? v : functor(v);
+//       return tip
+//     };
 
-      return tip
-    };
+//     // Public: sets or gets the root element anchor of the tooltip
+//     //
+//     // v - root element of the tooltip
+//     //
+//     // Returns root node of tip
+//     tip.rootElement = function(v) {
+//       if (!arguments.length) return rootElement
+//       rootElement = v == null ? v : functor(v);
 
-    // Public: destroys the tooltip and removes it from the DOM
-    //
-    // Returns a tip
-    tip.destroy = function() {
-      if (node) {
-        getNodeEl().remove();
-        node = null;
-      }
-      return tip
-    };
+//       return tip
+//     };
 
-    function d3TipDirection() { return 'n' }
-    function d3TipOffset() { return [0, 0] }
-    function d3TipHTML() { return ' ' }
+//     // Public: destroys the tooltip and removes it from the DOM
+//     //
+//     // Returns a tip
+//     tip.destroy = function() {
+//       if (node) {
+//         getNodeEl().remove();
+//         node = null;
+//       }
+//       return tip
+//     };
 
-    var directionCallbacks = d3Collection.map({
-          n:  directionNorth,
-          s:  directionSouth,
-          e:  directionEast,
-          w:  directionWest,
-          nw: directionNorthWest,
-          ne: directionNorthEast,
-          sw: directionSouthWest,
-          se: directionSouthEast
-        }),
-        directions = directionCallbacks.keys();
+//     function d3TipDirection() { return 'n' }
+//     function d3TipOffset() { return [0, 0] }
+//     function d3TipHTML() { return ' ' }
 
-    function directionNorth() {
-      var bbox = getScreenBBox(this);
-      return {
-        top:  bbox.n.y - node.offsetHeight,
-        left: bbox.n.x - node.offsetWidth / 2
-      }
-    }
+//     var directionCallbacks = d3Collection.map({
+//           n:  directionNorth,
+//           s:  directionSouth,
+//           e:  directionEast,
+//           w:  directionWest,
+//           nw: directionNorthWest,
+//           ne: directionNorthEast,
+//           sw: directionSouthWest,
+//           se: directionSouthEast
+//         }),
+//         directions = directionCallbacks.keys();
 
-    function directionSouth() {
-      var bbox = getScreenBBox(this);
-      return {
-        top:  bbox.s.y,
-        left: bbox.s.x - node.offsetWidth / 2
-      }
-    }
+//     function directionNorth() {
+//       var bbox = getScreenBBox(this);
+//       return {
+//         top:  bbox.n.y - node.offsetHeight,
+//         left: bbox.n.x - node.offsetWidth / 2
+//       }
+//     }
 
-    function directionEast() {
-      var bbox = getScreenBBox(this);
-      return {
-        top:  bbox.e.y - node.offsetHeight / 2,
-        left: bbox.e.x
-      }
-    }
+//     function directionSouth() {
+//       var bbox = getScreenBBox(this);
+//       return {
+//         top:  bbox.s.y,
+//         left: bbox.s.x - node.offsetWidth / 2
+//       }
+//     }
 
-    function directionWest() {
-      var bbox = getScreenBBox(this);
-      return {
-        top:  bbox.w.y - node.offsetHeight / 2,
-        left: bbox.w.x - node.offsetWidth
-      }
-    }
+//     function directionEast() {
+//       var bbox = getScreenBBox(this);
+//       return {
+//         top:  bbox.e.y - node.offsetHeight / 2,
+//         left: bbox.e.x
+//       }
+//     }
 
-    function directionNorthWest() {
-      var bbox = getScreenBBox(this);
-      return {
-        top:  bbox.nw.y - node.offsetHeight,
-        left: bbox.nw.x - node.offsetWidth
-      }
-    }
+//     function directionWest() {
+//       var bbox = getScreenBBox(this);
+//       return {
+//         top:  bbox.w.y - node.offsetHeight / 2,
+//         left: bbox.w.x - node.offsetWidth
+//       }
+//     }
 
-    function directionNorthEast() {
-      var bbox = getScreenBBox(this);
-      return {
-        top:  bbox.ne.y - node.offsetHeight,
-        left: bbox.ne.x
-      }
-    }
+//     function directionNorthWest() {
+//       var bbox = getScreenBBox(this);
+//       return {
+//         top:  bbox.nw.y - node.offsetHeight,
+//         left: bbox.nw.x - node.offsetWidth
+//       }
+//     }
 
-    function directionSouthWest() {
-      var bbox = getScreenBBox(this);
-      return {
-        top:  bbox.sw.y,
-        left: bbox.sw.x - node.offsetWidth
-      }
-    }
+//     function directionNorthEast() {
+//       var bbox = getScreenBBox(this);
+//       return {
+//         top:  bbox.ne.y - node.offsetHeight,
+//         left: bbox.ne.x
+//       }
+//     }
 
-    function directionSouthEast() {
-      var bbox = getScreenBBox(this);
-      return {
-        top:  bbox.se.y,
-        left: bbox.se.x
-      }
-    }
+//     function directionSouthWest() {
+//       var bbox = getScreenBBox(this);
+//       return {
+//         top:  bbox.sw.y,
+//         left: bbox.sw.x - node.offsetWidth
+//       }
+//     }
 
-    function initNode() {
-      var div = d3Selection.select(document.createElement('div'));
-      div
-        .style('position', 'absolute')
-        .style('top', 0)
-        .style('opacity', 0)
-        .style('pointer-events', 'none')
-        .style('box-sizing', 'border-box');
+//     function directionSouthEast() {
+//       var bbox = getScreenBBox(this);
+//       return {
+//         top:  bbox.se.y,
+//         left: bbox.se.x
+//       }
+//     }
 
-      return div.node()
-    }
+//     function initNode() {
+//       var div = d3Selection.select(document.createElement('div'));
+//       div
+//         .style('position', 'absolute')
+//         .style('top', 0)
+//         .style('opacity', 0)
+//         .style('pointer-events', 'none')
+//         .style('box-sizing', 'border-box');
 
-    function getSVGNode(element) {
-      var svgNode = element.node();
-      if (!svgNode) return null
-      if (svgNode.tagName.toLowerCase() === 'svg') return svgNode
-      return svgNode.ownerSVGElement
-    }
+//       return div.node()
+//     }
 
-    function getNodeEl() {
-      if (node == null) {
-        node = initNode();
-        // re-add node to DOM
-        rootElement.appendChild(node);
-      }
-      return d3Selection.select(node)
-    }
+//     function getSVGNode(element) {
+//       var svgNode = element.node();
+//       if (!svgNode) return null
+//       if (svgNode.tagName.toLowerCase() === 'svg') return svgNode
+//       return svgNode.ownerSVGElement
+//     }
 
-    // Private - gets the screen coordinates of a shape
-    //
-    // Given a shape on the screen, will return an SVGPoint for the directions
-    // n(north), s(south), e(east), w(west), ne(northeast), se(southeast),
-    // nw(northwest), sw(southwest).
-    //
-    //    +-+-+
-    //    |   |
-    //    +   +
-    //    |   |
-    //    +-+-+
-    //
-    // Returns an Object {n, s, e, w, nw, sw, ne, se}
-    function getScreenBBox(targetShape) {
-      var targetel   = target || targetShape;
+//     function getNodeEl() {
+//       if (node == null) {
+//         node = initNode();
+//         // re-add node to DOM
+//         rootElement.appendChild(node);
+//       }
+//       return d3Selection.select(node)
+//     }
 
-      while (targetel.getScreenCTM == null && targetel.parentNode != null) {
-        targetel = targetel.parentNode;
-      }
+//     // Private - gets the screen coordinates of a shape
+//     //
+//     // Given a shape on the screen, will return an SVGPoint for the directions
+//     // n(north), s(south), e(east), w(west), ne(northeast), se(southeast),
+//     // nw(northwest), sw(southwest).
+//     //
+//     //    +-+-+
+//     //    |   |
+//     //    +   +
+//     //    |   |
+//     //    +-+-+
+//     //
+//     // Returns an Object {n, s, e, w, nw, sw, ne, se}
+//     function getScreenBBox(targetShape) {
+//       var targetel   = target || targetShape;
 
-      var bbox       = {},
-          matrix     = targetel.getScreenCTM(),
-          tbbox      = targetel.getBBox(),
-          width      = tbbox.width,
-          height     = tbbox.height,
-          x          = tbbox.x,
-          y          = tbbox.y;
+//       while (targetel.getScreenCTM == null && targetel.parentNode != null) {
+//         targetel = targetel.parentNode;
+//       }
 
-      point.x = x;
-      point.y = y;
-      bbox.nw = point.matrixTransform(matrix);
-      point.x += width;
-      bbox.ne = point.matrixTransform(matrix);
-      point.y += height;
-      bbox.se = point.matrixTransform(matrix);
-      point.x -= width;
-      bbox.sw = point.matrixTransform(matrix);
-      point.y -= height / 2;
-      bbox.w = point.matrixTransform(matrix);
-      point.x += width;
-      bbox.e = point.matrixTransform(matrix);
-      point.x -= width / 2;
-      point.y -= height / 2;
-      bbox.n = point.matrixTransform(matrix);
-      point.y += height;
-      bbox.s = point.matrixTransform(matrix);
+//       var bbox       = {},
+//           matrix     = targetel.getScreenCTM(),
+//           tbbox      = targetel.getBBox(),
+//           width      = tbbox.width,
+//           height     = tbbox.height,
+//           x          = tbbox.x,
+//           y          = tbbox.y;
 
-      return bbox
-    }
+//       point.x = x;
+//       point.y = y;
+//       bbox.nw = point.matrixTransform(matrix);
+//       point.x += width;
+//       bbox.ne = point.matrixTransform(matrix);
+//       point.y += height;
+//       bbox.se = point.matrixTransform(matrix);
+//       point.x -= width;
+//       bbox.sw = point.matrixTransform(matrix);
+//       point.y -= height / 2;
+//       bbox.w = point.matrixTransform(matrix);
+//       point.x += width;
+//       bbox.e = point.matrixTransform(matrix);
+//       point.x -= width / 2;
+//       point.y -= height / 2;
+//       bbox.n = point.matrixTransform(matrix);
+//       point.y += height;
+//       bbox.s = point.matrixTransform(matrix);
 
-    // Private - replace D3JS 3.X d3.functor() function
-    function functor(v) {
-      return typeof v === 'function' ? v : function() {
-        return v
-      }
-    }
+//       return bbox
+//     }
 
-    return tip
-  }
+//     // Private - replace D3JS 3.X d3.functor() function
+//     function functor(v) {
+//       return typeof v === 'function' ? v : function() {
+//         return v
+//       }
+//     }
 
-  return index;
+//     return tip
+//   }
 
-})));
+//   return index;
+
+// })));


### PR DESCRIPTION
Hello mattflor,

i'm working for Ebner Stolz and we are currently developing a tool using R and Shiny. Part of our code relies on your great chorddiag-library.

Unfortunately, there is a bug with the tooltips. Your library uses the _d3-tip_ library. This library generates a new div for each tooltip. The problem is, that these tooltip-divs are added to the body of the DOM as a direct child, not to the svg-container.
Whenever a user clicks a chord, the chorddiag-javascript sends a request to the Shiny-Server and eventually the Shiny-Server initiates an update of the Chord Diagram, therefore updating or re-creating the elements contained in the svg-container. But because the tooltip-divs aren't descendents of the svg container, new ToolTip-divs are created on every update. This results in dangling ToolTips whenever the user clicks on a chord:
![dangling tooltips](https://user-images.githubusercontent.com/70743341/92567388-e7ae1200-f27d-11ea-93fa-5da65e03eaf3.PNG)

To solve this problem, I implemented the creation of tooltips and the behaivor of showing, hiding and positioning these tooltips when the user hovers the mouse over the svg-elements (actually my code generates just a single tool tip-div and reuses it). The code is embedded directly in the file _inst/htmlwidgets/lib/chorddiag/chorddiag.js_. The code doesn't rely on the d3-tip anymore, so this library can be removed from the repository. The dependency in the _inst/htmlwidgets/chorddiag.yaml_ is already commented out. After all, I added about 60 lines of code but removed the 340 lines of the d3-tip-library. My code runs faster, is much more intuitive than the d3-tip and should be easier to maintain. 

My changes don't affect the usage of the library in any way. Users already relying on your library won't have to change a single line of code.

If you have any questions, please don't hesitate contacting me. You can contact me via e-mail: tobias.abend@ebnerstolz.de.

Best regards
Tobias